### PR TITLE
Update failover scripts and documentation to reference goc.stfc.ac.uk, not next.gocdb.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ swtich between the failover instance and the production instance. You should mon
 ```bash
 nslookup goc.egi.eu
 # check this returns the following output referring to
-# next.gocdb.eu
+# goc.stfc.ac.uk
 	Non-authoritative answer:
-	goc.egi.eu canonical name = next.gocdb.eu.
-	Name: next.gocdb.eu
+	goc.egi.eu canonical name = goc.stfc.ac.uk.
+	Name: goc.stfc.ac.uk
 	Address: 130.246.143.160
 ```
 

--- a/nsupdate_goc/goc_production.sh
+++ b/nsupdate_goc/goc_production.sh
@@ -1,10 +1,10 @@
-echo "changing goc.egi.eu DNS record at ns.mui.cz to next.gocdb.eu"
+echo "changing goc.egi.eu DNS record at ns.mui.cz to goc.stfc.ac.uk"
 echo
 nsupdate -k goc.egi.eu_ns.muni.cz_key.conf  <<EOF
 server ns.muni.cz
 zone egi.eu
 update delete goc.egi.eu. CNAME
-update add goc.egi.eu. 60 CNAME next.gocdb.eu.
+update add goc.egi.eu. 60 CNAME goc.stfc.ac.uk.
 show
 send
 EOF


### PR DESCRIPTION
Without this, using the failover and then undoing it would point goc.egi.eu back to next.gocdb.eu, rather than goc.stfc.ac.uk (i.e. the current production set up)

It should be documented (where?) that the current failover mechanism is IPv4 only.