### PR TITLE
Refactor to ignore a failure for the grace period 

### DIFF
--- a/importDBdmpFile/1_runDbUpdate.sh
+++ b/importDBdmpFile/1_runDbUpdate.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 
-# Script for downloading the gocdb5 db dmp file and importing into the 
-# local oracle xe instance using sqlplus. 
-# Notes: 
-# - The updatelog.txt file is appended each time with log messages whenever the script is ran. 
+# Script for downloading the gocdb5 db dmp file and importing into the
+# local oracle xe instance using sqlplus.
+# Notes:
+# - The updatelog.txt file is appended each time with log messages whenever the script is ran.
 # - The last successfully .dmp file is stored in the 'lastImportedDmpFile' dir
-#   under a file name with the datetime appended (creating a manual backup of the last imported .dmp file).  
-# - The script echos messages to the stdout if there is a failure for whatever reason and exits 
-#   with a non-zero return code. 
-# - No email is invoked from this script, but if the script is ran by e.g. cron.hourly, the cron 
-#   daemon will email the echoed messages for us when the script fails. 
-# 
-# David Meredith 
+#   under a file name with the datetime appended (creating a manual backup of the last imported .dmp file).
+# - The script echos messages to the stdout if there is a failure for whatever reason and exits
+#   with a non-zero return code.
+# - No email is invoked from this script, but if the script is ran by e.g. cron.hourly, the cron
+#   daemon will email the echoed messages for us when the script fails.
+#
+# David Meredith
 
-# cd into dir where child scripts are located 
+# cd into dir where child scripts are located
 cd /root/gocdb-failover-scripts/importDBdmpFile
 
-#Setup our env vars 
-####################################  
+#Setup our env vars
+####################################
 . ./ora11gEnvVars.sh
 
 updatelog=./updateLog.txt
 
 function logger {
   echo $*>> $updatelog
-  # todo - add a function to email admins is issue occurs and invoke from above 
+  # todo - add a function to email admins is issue occurs and invoke from above
   # /bin/mail -s 'gocdump is old' gocdb-admins@mailman.egi.eu < /etc/cron.hourly/gocdumpold.txt
 }
 
@@ -35,47 +35,47 @@ function logger {
 
 logger "==============Updating Log $(/bin/date) ================="
 
-# Download the dmp file 
+# Download the dmp file
 ####################################
 getDumpOutput=`./getDump.sh 2>&1`
-getDumpReturnCode=$? 
-#echo $getDumpOutput 
-if [ $getDumpReturnCode != 0 ]; then 
-  logger "wget failed [$getDumpReturnCode]" 
+getDumpReturnCode=$?
+#echo $getDumpOutput
+if [ $getDumpReturnCode != 0 ]; then
+  logger "wget failed [$getDumpReturnCode]"
   logger "$getDumpOutput"
-  echo "wget failed [$getDumpReturnCode]" 
+  echo "wget failed [$getDumpReturnCode]"
   echo "$getDumpOutput"
-  exit $getDumpReturnCode 
+  exit $getDumpReturnCode
   #exit 0
 #else
 #  logger "wget downloaded ok"
-fi 
+fi
 
 
-# Drop gocdb user (gocdb5 user is recreated when doing the impdb) 
+# Drop gocdb user (gocdb5 user is recreated when doing the impdb)
 ####################################
 dropGocdbUserOutput=`./dropGocdbUser2.sh 2>&1`
 dropGocdbExitCode=$?
 #echo $dropGocdbUserOutput
-if [ $dropGocdbExitCode != 0 ]; then 
-  logger "Unknown error on drop gocdb user [$dropGocdbExitCode]" 
+if [ $dropGocdbExitCode != 0 ]; then
+  logger "Unknown error on drop gocdb user [$dropGocdbExitCode]"
   logger "$dropGocdbUserOutput"
-  echo "Unknown error on drop gocdb user [$dropGocdbExitCode]" 
+  echo "Unknown error on drop gocdb user [$dropGocdbExitCode]"
   echo "$dropGocdbUserOutput"
   exit $dropGocdbExitCode
-fi 
+fi
 
-# manually parse the output string for errors 
+# manually parse the output string for errors
 #grepOutput=`grep -i error <<< $dropGocdbUserOutput`
 grepOutput=$(echo $dropGocdbUserOutput | grep -i error)
-grepResultCode=$? 
-if [ $grepResultCode = 0 ]; then 
-    # exit code of 0 means the string 'error' was matched 
+grepResultCode=$?
+if [ $grepResultCode = 0 ]; then
+    # exit code of 0 means the string 'error' was matched
     logger "Dropping GOCDB5 user failed [$grepResultCode]"
     logger "$grepOutput"
     echo "Dropping GOCDB5 user failed [$grepResultCode]"
     echo "$grepOutput"
-    exit 1 
+    exit 1
 #else
 #    logger "gocdb5 user dropped ok"
 fi
@@ -93,56 +93,56 @@ if [ $loadDataExitCode != 0 ]; then
   exit $loadDataExitCode
 fi
 
-# manually parse the output string for errors  
+# manually parse the output string for errors
 grepLoadDataOutput=$(echo $loadDataOutput | grep -i error)
-grepLoadDataExitCode=$? 
+grepLoadDataExitCode=$?
 if [ $grepLoadDataExitCode = 0 ]; then
-  # exit code of 0 means the string 'error' was matched 
+  # exit code of 0 means the string 'error' was matched
   logger "Load data failed [$grepLoadDataExitCode]"
   logger "$grepLoadDataOutput"
   echo "Load data failed [$grepLoadDataExitCode]"
   echo "$grepLoadDataOutput"
-  exit 1; 
+  exit 1;
 #else
 #  logger "loaded data ok"
-fi 
+fi
 
-# gather stats 
+# gather stats
 ####################################
 gatherStatsOutput=`./gatherStats.sh 2>&1`
 gatherStatsExitCode=$?
-#echo $gatherStatsOutput 
+#echo $gatherStatsOutput
 if [ $gatherStatsExitCode != 0 ]; then
   logger "unknown error on gatherStats [$gatherStatsExitCode]"
-  logger "$gatherStatsOutput" 
+  logger "$gatherStatsOutput"
   echo "unknown error on gatherStats [$gatherStatsExitCode]"
-  echo "$gatherStatsOutput" 
+  echo "$gatherStatsOutput"
   exit $gatherStatsExitCode
 fi
 
-# manually parse the output string for errors 
+# manually parse the output string for errors
 grepGatherStatsOutput=$(echo $gatherStatsOutput | grep -i error)
-grepGatherStatsExitCode=$? 
+grepGatherStatsExitCode=$?
 if [ $grepGatherStatsExitCode = 0 ]; then
-  # exit code of 0 means the string 'error' was matched 
-  logger "gatherStats parsing failed [$grepGatherStatsExitCode]" 
+  # exit code of 0 means the string 'error' was matched
+  logger "gatherStats parsing failed [$grepGatherStatsExitCode]"
   logger "$grepGatherStatsOutput"
-  echo "gatherStats parsing failed [$grepGatherStatsExitCode]" 
+  echo "gatherStats parsing failed [$grepGatherStatsExitCode]"
   echo "$grepGatherStatsOutput"
-  exit 1; 
+  exit 1;
 #else
 #  logger "stats gathered ok"
-fi 
+fi
 
 
-# Create a copy of the last successfully imported dmp file and 
-# store this in the lastImportedDmpFile dir with the time and date appended 
-# to the file name 
+# Create a copy of the last successfully imported dmp file and
+# store this in the lastImportedDmpFile dir with the time and date appended
+# to the file name
 if [ ! -d lastImportedDmpFile ]; then
   mkdir lastImportedDmpFile
 fi
 
-# cd into the dir (this directory must exist) 
+# cd into the dir (this directory must exist)
 cd lastImportedDmpFile
 cdReturnCode=$?
 if [ $cdReturnCode != 0 ]; then
@@ -159,7 +159,7 @@ dmpTarget=$dmpTargetFN.$dmpCopyExt
 cp /tmp/goc5dump.dmp $dmpTarget
 cpDmpReturnCode=$?
 if [ $cpDmpReturnCode != 0 ]; then
-  # cp failed so exit early as we don't want to overwrite 
+  # cp failed so exit early as we don't want to overwrite
   exit $cpDmpReturnCode
 fi
 
@@ -172,5 +172,5 @@ cd ..
 
 # Do not remove following line - another process relies on this exact string
 # being the last line in the log file
-logger "completed ok" 
+logger "completed ok"
 # Do not add any further "logger" statements after above line

--- a/importDBdmpFile/1_runDbUpdate.sh
+++ b/importDBdmpFile/1_runDbUpdate.sh
@@ -172,5 +172,6 @@ cd ..
 
 # Do not remove following line - another process relies on this exact string
 # being the last line in the log file
+echo "`date --iso-8601='seconds'` completed ok"
 logger "completed ok"
 # Do not add any further "logger" statements after above line

--- a/importDBdmpFile/1_runDbUpdate.sh
+++ b/importDBdmpFile/1_runDbUpdate.sh
@@ -172,6 +172,6 @@ cd ..
 
 # Do not remove following line - another process relies on this exact string
 # being the last line in the log file
-echo "`date --iso-8601='seconds'` completed ok"
+echo "$(date --iso-8601='seconds') completed ok"
 logger "completed ok"
 # Do not add any further "logger" statements after above line

--- a/importDBdmpFile/check_db_dump_recent.py
+++ b/importDBdmpFile/check_db_dump_recent.py
@@ -7,16 +7,17 @@ Specifically, it checks the log file passed as the first arguement for evidence
 the process has suceeded / failed recently.
 
 It assumes the log file is formatted as follows:
-2021-08-02T08:40:01+0000
+2022-10-04T09:40:01+0000
+2022-10-04T09:40:01+0000 completed ok
+2022-10-04T10:40:01+0000
+2022-10-04T10:40:01+0000 completed ok
+2022-10-04T11:40:01+0000
 An Error
-2021-08-02T09:40:01+0000
+2022-10-04T12:40:01+0000
 An Error
 Another Error
-2021-08-02T10:40:01+0000
-2021-08-02T11:40:01+0000
-2021-08-02T12:40:01+0000
-2021-08-02T13:40:01+0000
-2021-08-02T14:40:01+0000
+2022-10-04T13:40:01+0000
+2022-10-04T14:40:01+0000 completed ok
 """
 from datetime import datetime, timedelta, timezone
 import sys
@@ -30,6 +31,9 @@ RETURN_CODE_UNKNOWN = 3
 # This script will allow the latest run of the failover process to be this many
 # minutes ago without returning RETURN_CODE_CRITICAL.
 GRACE_PERIOD_MINUTES = 447
+
+# The string the database update script outputs on a sucessful restore.
+OK_STRING = "completed ok"
 
 # Wrap everything in a try...except block so we can return RETURN_CODE_UNKNOWN
 # on a unexpected failure.
@@ -47,26 +51,29 @@ try:
     # "Couldn't open/read the provided file" differently.
     try:
         with open(log_file, 'r') as log_file:
-            lines = log_file.read().splitlines()
-            last_line = lines[-1]
+            line_list = log_file.read().splitlines()
     except IOError:
         print("An error occured trying to open/read {0}".format(log_file))
         sys.exit(RETURN_CODE_CRITICAL)
 
-    # Convert the last line of the log to a timestamp.
-    # Use a inner try...except block to handle the somewhat more expected error
-    # of "the failover process ran, but something went wrong" differently.
-    try:
-        last_success = datetime.strptime(last_line, "%Y-%m-%dT%H:%M:%S%z")
-    except ValueError:
-        print("An error occured: {0}".format(last_line))
-        sys.exit(RETURN_CODE_CRITICAL)
+    for line in reversed(line_list):
+        # If OK_STRING is in the line we are looking at, we need to extract
+        # the timestamp from that line to determine when the failover
+        # process last succeeded.
+        if OK_STRING in line:
+            last_success_string = line.split(" ")[0]
+            last_success_datetime = datetime.strptime(
+                last_success_string,
+                "%Y-%m-%dT%H:%M:%S%z"
+            )
 
-    print("The failover process last suceeded at %s" % last_success)
+    print("The failover process last succeeded at %s." % last_success_datetime)
+
     # If the failover process hasn't suceeded in a while, the timestamp will be
     # old and we want to treat that as an error.
     grace_period_timedelta = timedelta(minutes=GRACE_PERIOD_MINUTES)
-    if last_success < (datetime.now(timezone.utc) - grace_period_timedelta):
+    grace_period_cutoff = datetime.now(timezone.utc) - grace_period_timedelta
+    if last_success_datetime < grace_period_cutoff:
         sys.exit(RETURN_CODE_CRITICAL)
 
     # If we get here, it's all good man.


### PR DESCRIPTION
- currently, an error in the pipeline immediately causes the next icinga check to raise an error.
- this led to flapping hour to hour, generating emails that were ignored.
- this should mean we only get alerts if the failover pipeline has not succeeded within the grace period.
- adding an output on a successful restore in `1_runDbUpdate.sh` simplifies the logic needed by this check. We don't have to worry about "if/when the pipeline failed?", we only care about "when did it last succeed?".