### PR TITLE
Only specify major version of codecov-action

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,4 +40,4 @@ jobs:
       run: coverage run --branch --source=check -m unittest discover --buffer
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.0.2
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
- always give us the latest version of the action in the relevant major series
- reduce the number of dependabot PRs to review
- bring consistency with the other actions in this file